### PR TITLE
fix: env variable ELASTIC_INDEX_DATEFORMAT set only default value

### DIFF
--- a/filebeat.yml
+++ b/filebeat.yml
@@ -24,7 +24,7 @@ output.elasticsearch:
   protocol: "${ELASTIC_PROTOCOL:http}"
   username: "${ELASTIC_USERNAME:''}"
   password: "${ELASTIC_PASSWORD:''}"
-  index: "${ELASTIC_INDEX_PREFIX:filebeat}-%{+${ELASTIC_INDEX_DATEFORMAT:+yyyy.MM.dd}}"
+  index: "${ELASTIC_INDEX_PREFIX:filebeat}-%{+${ELASTIC_INDEX_DATEFORMAT:yyyy.MM.dd}}"
 
 setup.template:
   index: "${ELASTIC_INDEX_PREFIX:filebeat}-%{+${ELASTIC_INDEX_DATEFORMAT:yyyy.MM.dd}}"


### PR DESCRIPTION
…alue

| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  | No

## Description

fix env variable `ELASTIC_INDEX_DATEFORMAT` set only default value

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made changes in [CHANGELOG.md](https://github.com/512k/filebeat-udp-to-elastic-docker/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## YY.MM.DD`, if it does not exists
> * Add description under `Added`/`Changed`/`Fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of section
